### PR TITLE
Non-present persistenceXml file is not ignored

### DIFF
--- a/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/GenerateDdlMojo.java
+++ b/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/GenerateDdlMojo.java
@@ -111,7 +111,7 @@ public class GenerateDdlMojo extends AbstractMojo {
         required = false)
     private File persistenceXml;
 
-    @Parameter(defaultValue = "${project}", readonly = true)
+    @Component
     private transient MavenProject project;
 
     /**

--- a/src/test/java/de/jpdigital/maven/plugins/hibernate5ddl/tests/DdlMojoTest.java
+++ b/src/test/java/de/jpdigital/maven/plugins/hibernate5ddl/tests/DdlMojoTest.java
@@ -65,8 +65,6 @@ public class DdlMojoTest {
      */
     private GenerateDdlMojo mojo;
 
-    ;
-    
     public DdlMojoTest() {
     }
 
@@ -114,6 +112,32 @@ public class DdlMojoTest {
             //Delete the (now empty) test directory.
             Files.deleteIfExists(testDir);
         }
+    }
+
+    /**
+     * Check that no Exception is thrown when a non-existant file is injected
+     * into {@link GenerateDdlMojo::setPersistenceXml} and then executed.
+     */
+    @Test
+    public void persistenceXmlDoesntExist() throws MojoExecutionException,
+                                                   MojoFailureException,
+                                                   IOException {
+        mojo.setOutputDirectory(new File(TEST_DIR));
+
+        final String[] packages = new String[]{
+          "de.jpdigital.maven.plugins.hibernate5ddl.tests.entities",
+          "de.jpdigital.maven.plugins.hibernate5ddl.tests.entities2"
+        };
+        mojo.setPackages(packages);
+
+        final String[] dialects = new String[]{
+            "mysql5"
+        };
+        mojo.setDialects(dialects);
+
+        mojo.setPersistenceXml(new File("file/doesnt/exist"));
+
+        mojo.execute();
     }
 
     /**


### PR DESCRIPTION
The [persistenceXml](http://jpdigital.github.io/hibernate5-ddl-maven-plugin/gen-ddl-mojo.html#persistenceXml) documentation states, "if the file is not present it is ignored."  This is not really true as an exception is thrown if the file doesn't exist.

This pull request attempts to fix this case.  With the default value for that parameter, there doesn't seem to be a way -- using the `pom.xml` or command-line options -- to reset the `persistenceXml` property to `null`.