### PR TITLE
I find useful to add support for custom dialects. Please review this changes

### DIFF
--- a/hibernate5-ddl-maven-plugin-core/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/Dialect.java
+++ b/hibernate5-ddl-maven-plugin-core/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/Dialect.java
@@ -16,11 +16,16 @@
  */
 package de.jpdigital.maven.plugins.hibernate5ddl;
 
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * This enumeration provides constants for all dialects supported by Hibernate.
  *
- * The dialects supported by Hibernate can be found in the
- * <a href="http://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#database-dialect">
+ * The dialects supported by Hibernate can be found in the <a href=
+ * "http://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#database-dialect">
  * Hibernate documentation</a>. Also this enumeration provides the convenient
  * method {@link #getDialectClass()} for getting the class name of the Hibernate
  * dialect.
@@ -30,90 +35,149 @@ package de.jpdigital.maven.plugins.hibernate5ddl;
  *
  * @author <a href="mailto:jens.pelzetter@googlemail.com">Jens Pelzetter</a>
  */
-public enum Dialect {
+public class Dialect {
+	private static Map<String, String> map = new HashMap<>();
+	static {
+		map.put("ABSTRACT_HANA","org.hibernate.dialect.AbstractHANADialect");
+		map.put("CACHE71","org.hibernate.dialect.Cache71Dialect");
+		map.put("CUBRID","org.hibernate.dialect.CUBRIDDialect");
+		map.put("DATA_DIRECT_ORACLE9","org.hibernate.dialect.DataDirectOracle9Dialect");
+		map.put("DB2","org.hibernate.dialect.DB2Dialect");
+		map.put("DB297","org.hibernate.dialect.DB207");
+		map.put("DB2390","org.hibernate.dialect.DB2390Dialect");
+		map.put("DB2400","org.hibernate.dialect.DB2400Dialect");
+		map.put("DB2_AS400","org.hibernate.dialect.DB2400Dialect");
+		map.put("DB2_OS390","org.hibernate.dialect.DB2390Dialect");
+		map.put("DERBY","org.hibernate.dialect.DerbyDialect");
+		map.put("DERBY_10_5","org.hibernate.dialect.DerbyTenFiveDialect");
+		map.put("DERBY_10_6","org.hibernate.dialect.DerbyTenSixDialect");
+		map.put("DERBY_10_7","org.hibernate.dialect.DerbyTenSevenDialect");
+		map.put("FIREBIRD","org.hibernate.dialect.FirebirdDialect");
+		map.put("FRONTBASE","org.hibernate.dialect.FrontBaseDialect");
+		map.put("H2","org.hibernate.dialect.H2Dialect");
+		map.put("HANA_COLUMN_STORE","org.hibernate.dialect.HanaColumnStoreDialect");
+		map.put("HANA_ROW_STORE","org.hibernate.dialect.HanaRowStoreDialect");
+		map.put("HSQL","org.hibernate.dialect.HSQLDialect");
+		map.put("INFORMIX","org.hibernate.dialect.InformixDialect");
+		map.put("INFORMIX10","org.hibernate.dialect.Informix10Dialect");
+		map.put("INGRES","org.hibernate.dialect.IngresDialect");
+		map.put("INGRES9","org.hibernate.dialect.Ingres9Dialect");
+		map.put("INGRES10","org.hibernate.dialect.Ingres10Dialect");
+		map.put("INTERBASE","org.hibernate.dialect.InterbaseDialect");
+		map.put("INTERSYSTEMS_CACHE","org.hibernate.dialect.Cache71Dialect");
+		map.put("JDATASTORE","org.hibernate.dialect.JDataStoreDialect");
+		map.put("MARIADB","org.hibernate.dialect.MariaDBDialect");
+		map.put("MARIADB53","org.hibernate.dialect.MariaDB53Dialect");
+		map.put("MCKOISQL","org.hibernate.dialect.MckoiDialect");
+		map.put("MIMERSQL","org.hibernate.dialect.MimerSQLDialect");
+		map.put("MYSQL","org.hibernate.dialect.MySQLDialect");
+		map.put("MYSQL_INNODB","org.hibernate.dialect.MySQLInnoDBDialect");
+		map.put("MYSQL_MYISAM","org.hibernate.dialect.MySQLMyISAMDialect");
+		map.put("MYSQL5","org.hibernate.dialect.MySQL5Dialect");
+		map.put("MYSQL5_SPATIAL","org.hibernate.spatial.dialect.mysql.MySQL5SpatialDialect");
+		map.put("MYSQL5_INNODB_SPATIAL","org.hibernate.spatial.dialect.mysql.MySQL5InnoDBSpatialDialect");
+		map.put("MYSQL5_INNODB","org.hibernate.dialect.MySQL5InnoDBDialect");
+		map.put("MYSQL55","org.hibernate.dialect.MySQL55Dialect");
+		map.put("MYSQL57","org.hibernate.dialect.MySQL57Dialect");
+		map.put("MYSQL57_INNODB","org.hibernate.dialect.MySQL57InnoDBDialect");
+		map.put("ORACLE","org.hibernate.dialect.OracleDialect");
+		map.put("ORACLE8I","org.hibernate.dialect.Oracle8iDialect");
+		map.put("ORACLE9","org.hibernate.dialect.Oracle9Dialect");
+		map.put("ORACLE9I","org.hibernate.dialect.Oracle9iDialect");
+		map.put("ORACLE10G","org.hibernate.dialect.Oracle10gDialect");
+		map.put("ORACLE12C","org.hibernate.dialect.Oracle12cDialect");
+		map.put("ORACLE_SPATIAL_10G","org.hibernate.spatial.dialect.oracle.OracleSpatial10gDialect");
+		map.put("ORACLE_SPATIAL_SDO_10G","org.hibernate.spatial.dialect.oracle.OracleSpatialSDO10gDialect");
+		map.put("ORACLE_TIMES_TEN","org.hibernate.dialect.TimesTenDialect");
+		map.put("POINTBASE","org.hibernate.dialect.PointbaseDialect");
+		map.put("POSTGIS_PG82","org.hibernate.spatial.dialect.postgis.PostgisPG82Dialect");
+		map.put("POSTGIS_PG9","org.hibernate.spatial.dialect.postgis.PostgisPG9Dialect");
+		map.put("POSTGIS_PG91","org.hibernate.spatial.dialect.postgis.PostgisPG91Dialect");
+		map.put("POSTGRES_PLUS","org.hibernate.dialect.PostgresPlusDialect");
+		map.put("POSTGRESQL","org.hibernate.dialect.PostgreSQLDialect");
+		map.put("POSTGRESQL81","org.hibernate.dialect.PostgreSQL81Dialect");
+		map.put("POSTGRESQL82","org.hibernate.dialect.PostgreSQL82Dialect");
+		map.put("POSTGRESQL9","org.hibernate.dialect.PostgreSQL9Dialect");
+		map.put("POSTGRESQL91","org.hibernate.dialect.PostgreSQL91Dialect");
+		map.put("POSTGRESQL92","org.hibernate.dialect.PostgreSQL92Dialect");
+		map.put("PROGRESS","org.hibernate.dialect.ProgressDialect");
+		map.put("RDMSOS2200","org.hibernate.dialect.RDMSOS2200Dialect");
+		map.put("SAP_DB","org.hibernate.dialect.SAPDBDialect");
+		map.put("SAP_HANA_COL","org.hibernate.dialect.HANAColumnStoreDialect");
+		map.put("SAP_HANA_ROW","org.hibernate.dialect.HANARowStoreDialect");
+		map.put("SQLSERVER2000","org.hibernate.dialect.SQLServerDialect");
+		map.put("SQLSERVER2005","org.hibernate.dialect.SQLServer2005Dialect");
+		map.put("SQLSERVER2008","org.hibernate.dialect.SQLServer2008Dialect");
+		map.put("SQLSERVER2008_SPATIAL","org.hibernate.dialect.SQLServer2008SpatialDialect");
+		map.put("SQLSERVER2012","org.hibernate.dialect.SQLServer2012Dialect");
+		map.put("SYBASE","org.hibernate.dialect.SybaseDialect");
+		map.put("SYBASE11","org.hibernate.dialect.Sybase11Dialect");
+		map.put("SYBASE_ASE155","org.hibernate.dialect.SybaseASE15Dialect");
+		map.put("SYBASE_ASE157","org.hibernate.dialect.SybaseASE157Dialect");
+		map.put("SYBASE_ANYWHERE","org.hibernate.dialect.SybaseAnywhereDialect");
+		map.put("TERADATA","org.hibernate.dialect.TeradataDialect");
+		map.put("TERADATA14","org.hibernate.dialect.Teradata14Dialect");
+		map.put("UNISYS_OS_2200_RDMS","org.hibernate.dialect.RDMSOS2200Dialect");
+	}
 
-    ABSTRACT_HANA("org.hibernate.dialect.AbstractHANADialect"),
-    CACHE71("org.hibernate.dialect.Cache71Dialect"),
-    CUBRID("org.hibernate.dialect.CUBRIDDialect"),
-    DB2("org.hibernate.dialect.DB2Dialect"),
-    DB297("org.hibernate.dialect.DB207"),
-    DB2900("org.hibernate.dialect.DB2390Dialect"),
-    DB2400("org.hibernate.dialect.DB2400Dialect"),
-    DB2_AS400("org.hibernate.dialect.DB2400Dialect"),
-    DB2_OS390("org.hibernate.dialect.DB2390Dialect"),
-    DERBY_10_5("org.hibernate.dialect.DerbyTenFiveDialect"),
-    DERBY_10_6("org.hibernate.dialect.DerbyTenSixDialect"),
-    DERBY_10_7("org.hibernate.dialect.DerbyTenSevenDialect"),
-    FIREBIRD("org.hibernate.dialect.FirebirdDialect"),
-    FRONTBASE("org.hibernate.dialect.FrontBaseDialect"),
-    H2("org.hibernate.dialect.H2Dialect"),
-    HANA_COLUMN_STORE("org.hibernate.dialect.HanaColumnStoreDialect"),
-    HANA_ROW_STORE("org.hibernate.dialect.HanaRowStoreDialect"),
-    HSQL("org.hibernate.dialect.HSQLDialect"),
-    INFORMIX("org.hibernate.dialect.InformixDialect"),
-    INGRES("org.hibernate.dialect.IngresDialect"),
-    INGRES9("org.hibernate.dialect.Ingres9Dialect"),
-    INGRES10("org.hibernate.dialect.Ingres10Dialect"),
-    INTERBASE("org.hibernate.dialect.InterbaseDialect"),
-    INTERSYSTEMS_CACHE("org.hibernate.dialect.Cache71Dialect"),
-    JDATASTORE("org.hibernate.dialect.JDataStoreDialect"),
-    MCKOISQL("org.hibernate.dialect.MckoiDialect"),
-    MIMERSQL("org.hibernate.dialect.MimerSQLDialect"),
-    MYSQL("org.hibernate.dialect.MySQLDialect"),
-    MYSQL_INNODB("org.hibernate.dialect.MySQLInnoDBDialect"),
-    MYSQL_MYISAM("org.hibernate.dialect.MySQLMyISAMDialect"),
-    MYSQL5("org.hibernate.dialect.MySQL5Dialect"),
-    MYSQL5_INNODB("org.hibernate.dialect.MySQL5InnoDBDialect"),
-    MYSQL57_INNODB("org.hibernate.dialect.MySQL57InnoDBDialect"),
-    ORACLE8I("org.hibernate.dialect.Oracle8iDialect"),
-    ORACLE9I("org.hibernate.dialect.Oracle9iDialect"),
-    ORACLE10G("org.hibernate.dialect.Oracle10gDialect"),
-    ORACLE12C("org.hibernate.dialect.Oracle12cDialect"),
-    ORACLE_TIMES_TEN("org.hibernate.dialect.TimesTenDialect"),
-    POINTBASE("org.hibernate.dialect.PointbaseDialect"),
-    POSTGRES_PLUS("org.hibernate.dialect.PostgresPlusDialect"),
-    POSTGRESQL81("org.hibernate.dialect.PostgreSQL81Dialect"),
-    POSTGRESQL82("org.hibernate.dialect.PostgreSQL82Dialect"),
-    POSTGRESQL9("org.hibernate.dialect.PostgreSQL9Dialect"),
-    PROGRESS("org.hibernate.dialect.ProgressDialect"),
-    SAP_DB("org.hibernate.dialect.SAPDBDialect"),
-    SAP_HANA_COL("org.hibernate.dialect.HANAColumnStoreDialect"),
-    SAP_HANA_ROW("org.hibernate.dialect.HANARowStoreDialect"),
-    SQLSERVER2000("org.hibernate.dialect.SQLServerDialect"),
-    SQLSERVER2005("org.hibernate.dialect.SQLServer2005Dialect"),
-    SQLSERVER2008("org.hibernate.dialect.SQLServer2008Dialect"),
-    SQLSERVER2012("org.hibernate.dialect.SQLServer2012Dialect"),
-    SYBASE("org.hibernate.dialect.SybaseDialect"),
-    SYBASE11("org.hibernate.dialect.Sybase11Dialect"),
-    SYBASE_ASE155("org.hibernate.dialect.SybaseASE15Dialect"),
-    SYBASE_ASE157("org.hibernate.dialect.SybaseASE157Dialect"),
-    SYBASE_ANYWHERE("org.hibernate.dialect.SybaseAnywhereDialect"),
-    TERADATA("org.hibernate.dialect.TeradataDialect"),
-    UNISYS_OS_2200_RDMS("org.hibernate.dialect.RDMSOS2200Dialect");
+	/**
+	 * Property for holding the name of the Hibernate dialect class.
+	 */
+	private final String dialectCode;
+	/**
+	 * Property for holding the name of the Hibernate dialect class.
+	 */
+	private final String dialectClass;
 
-    /**
-     * Property for holding the name of the Hibernate dialect class.
-     */
-    private final String dialectClass;
+	/**
+	 * Private constructor, used to create the Enum instances for each dialect.
+	 *
+	 * @param dialectClass
+	 *            The dialect class for the specific dialect.
+	 */
+	public Dialect(final String dialectClass) {
+		String dialect = dialectClass.toUpperCase(Locale.ENGLISH);
+		if (map.containsKey(dialect)) {
+			this.dialectClass = map.get(dialect);
+			this.dialectCode = dialect.toLowerCase(Locale.ENGLISH);
+		} else {
+			// Commented out due to different classpath and i can't check correctness here
+//			try {
+//				this.getClass().getClassLoader().loadClass(dialectClass);
+//			} catch (Exception e) {
+//				throw new IllegalArgumentException(dialectClass);
+//			}
+			this.dialectClass = dialectClass;
+			this.dialectCode = null;
+		}
+	}
 
-    /**
-     * Private constructor, used to create the Enum instances for each dialect.
-     *
-     * @param dialectClass The dialect class for the specific dialect.
-     */
-    private Dialect(final String dialectClass) {
-        this.dialectClass = dialectClass;
-    }
+	/**
+	 * Getter for the dialect class.
+	 *
+	 * @return The name of the dialect class, for example
+	 *         {@code org.hibernate.dialect.PostgreSQL9Dialect}
+	 */
+	public String getDialectClass() {
+		return dialectClass;
+	}
 
-    /**
-     * Getter for the dialect class.
-     *
-     * @return The name of the dialect class, for example
-     *         {@code org.hibernate.dialect.PostgreSQL9Dialect} for
-     *         {@link #POSTGRESQL9}.
-     */
-    public String getDialectClass() {
-        return dialectClass;
-    }
+	public String name() {
+		if (dialectCode != null) {
+			return dialectCode;
+		} else {
+			String cls[] = dialectClass.split("\\.");
+			String simpleName = cls[cls.length - 1];
+			return simpleName.toLowerCase(Locale.ENGLISH);
+		}
+	}
 
+	public static Set<String> values() {
+		return map.keySet();
+	}
+
+	@Override
+	public String toString() {
+		return "Dialect [dialectCode=" + dialectCode + ", dialectClass=" + dialectClass + "]";
+	}
 }

--- a/hibernate52-ddl-maven-plugin/src/test/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlMojoTest.java
+++ b/hibernate52-ddl-maven-plugin/src/test/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlMojoTest.java
@@ -459,15 +459,14 @@ public class DdlMojoTest {
     }
 
     /**
-     * Check if {@link MojoExecutionException} is thrown if an illegal dialect
-     * if configured.
+     * Checks if {@link MojoFailureException} is thrown if an illegal dialect if
+     * configured.
      *
      * @throws MojoExecutionException if the Mojo can't be executed.
      * @throws MojoFailureException   if the execution of the Mojo fails
      *                                (expected here)
      */
-    @Test(expected
-              = MojoFailureException.class)
+    @Test(expected = MojoFailureException.class)
     public void illegalDialect() throws MojoExecutionException,
                                         MojoFailureException {
         mojo.setOutputDirectory(new File(TEST_DIR));


### PR DESCRIPTION
Some time it is useful to add some customization to generated SQL. Like setting encoding for VARCHAR columns or something. Also it is possible that schema dialect might differ from runtime dialect.

Support for more Dialects
Add support for more dialectCodes
Update Dialect.java
Incorrect dialect handling/error message changed.