### PR TITLE
Use Hibernate-core artifact for Hibernate 5.2 and up

### DIFF
--- a/hibernate52-ddl-maven-plugin/pom.xml
+++ b/hibernate52-ddl-maven-plugin/pom.xml
@@ -98,7 +98,7 @@
         
         <dependency>
             <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
+            <artifactId>hibernate-core</artifactId>
             <version>5.2.10.Final</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Use Hibernate-core artifact for Hibernate 5.2 and up, as the hibernate-entitymanager artifact is deprecated. It was even temorarily removed at 5.2.0 and will be removed again with the introduction of Hibernate 6.

https://hibernate.atlassian.net/browse/HHH-10823