### PR TITLE
GitHub 28 set persistence properties in pom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.releaseBackupi
 
 *.log
+/hibernate5-ddl-maven-plugin-core/nbproject/

--- a/hibernate50-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate50.java
+++ b/hibernate50-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate50.java
@@ -87,11 +87,6 @@ public class DdlGeneratorHibernate50 implements DdlGenerator {
                 )
                 .filter(
                     property -> !property.getKey().equals(
-                        "hibernate.hbm2ddl.auto"
-                    )
-                )
-                .filter(
-                    property -> !property.getKey().equals(
                         "hibernate.dialect"
                     )
                 )

--- a/hibernate50-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate50.java
+++ b/hibernate50-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate50.java
@@ -40,6 +40,8 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -60,7 +62,7 @@ public class DdlGeneratorHibernate50 implements DdlGenerator {
         throws MojoFailureException {
 
         final StandardServiceRegistryBuilder registryBuilder
-                                                 = new StandardServiceRegistryBuilder();
+            = new StandardServiceRegistryBuilder();
         processPersistenceXml(registryBuilder, mojo);
 
         if (mojo.isCreateDropStatements()) {
@@ -71,6 +73,48 @@ public class DdlGeneratorHibernate50 implements DdlGenerator {
         }
 
         registryBuilder.applySetting("hibernate.dialect", dialectClassName);
+
+        if (!mojo.getPersistenceProperties().isEmpty()) {
+            mojo.getLog().info("Applying persistence properties set in POM...");
+            final Map<String, String> properties = mojo
+                .getPersistenceProperties()
+                .entrySet()
+                .stream()
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.hbm2ddl.auto"
+                    )
+                )
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.hbm2ddl.auto"
+                    )
+                )
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.dialect"
+                    )
+                )
+                .collect(
+                    Collectors.toMap(
+                        property -> property.getKey(),
+                        property -> property.getValue()
+                    )
+                );
+
+            for (final Map.Entry<String, String> property : properties
+                .entrySet()) {
+                mojo.getLog().info(
+                    String.format(
+                        "Setting peristence property %s = %s",
+                        property.getKey(),
+                        property.getValue()
+                    )
+                );
+            }
+
+            registryBuilder.applySettings(properties);
+        }
 
         final StandardServiceRegistry standardRegistry = registryBuilder.build();
 
@@ -134,7 +178,7 @@ public class DdlGeneratorHibernate50 implements DdlGenerator {
      *
      * @param registryBuilder {@link StandardServiceRegistryBuilder} from
      *                        Hibernate.
-     * @param mojo The plugin Mojo.
+     * @param mojo            The plugin Mojo.
      */
     private void processPersistenceXml(
         final StandardServiceRegistryBuilder registryBuilder,
@@ -187,6 +231,7 @@ public class DdlGeneratorHibernate50 implements DdlGenerator {
     private static class PersistenceXmlHandler extends DefaultHandler {
 
         private final transient StandardServiceRegistryBuilder registryBuilder;
+
         private final transient Set<String> propertiesToUse;
 
         private final transient Log log;

--- a/hibernate51-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate51.java
+++ b/hibernate51-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate51.java
@@ -41,6 +41,8 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -72,6 +74,48 @@ public class DdlGeneratorHibernate51 implements DdlGenerator {
         }
 
         registryBuilder.applySetting("hibernate.dialect", dialectClassName);
+
+        if (!mojo.getPersistenceProperties().isEmpty()) {
+            mojo.getLog().info("Applying persistence properties set in POM...");
+            final Map<String, String> properties = mojo
+                .getPersistenceProperties()
+                .entrySet()
+                .stream()
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.hbm2ddl.auto"
+                    )
+                )
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.hbm2ddl.auto"
+                    )
+                )
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.dialect"
+                    )
+                )
+                .collect(
+                    Collectors.toMap(
+                        property -> property.getKey(),
+                        property -> property.getValue()
+                    )
+                );
+
+            for (final Map.Entry<String, String> property : properties
+                .entrySet()) {
+                mojo.getLog().info(
+                    String.format(
+                        "Setting peristence property %s = %s",
+                        property.getKey(),
+                        property.getValue()
+                    )
+                );
+            }
+
+            registryBuilder.applySettings(properties);
+        }
 
         final StandardServiceRegistry standardRegistry = registryBuilder.build();
 

--- a/hibernate51-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate51.java
+++ b/hibernate51-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate51.java
@@ -88,11 +88,6 @@ public class DdlGeneratorHibernate51 implements DdlGenerator {
                 )
                 .filter(
                     property -> !property.getKey().equals(
-                        "hibernate.hbm2ddl.auto"
-                    )
-                )
-                .filter(
-                    property -> !property.getKey().equals(
                         "hibernate.dialect"
                     )
                 )

--- a/hibernate51-ddl-maven-plugin/src/test/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlMojoTest.java
+++ b/hibernate51-ddl-maven-plugin/src/test/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlMojoTest.java
@@ -38,8 +38,13 @@ import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 
 
 /**

--- a/hibernate52-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate52.java
+++ b/hibernate52-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate52.java
@@ -88,11 +88,6 @@ public class DdlGeneratorHibernate52 implements DdlGenerator {
                 )
                 .filter(
                     property -> !property.getKey().equals(
-                        "hibernate.hbm2ddl.auto"
-                    )
-                )
-                .filter(
-                    property -> !property.getKey().equals(
                         "hibernate.dialect"
                     )
                 )

--- a/hibernate52-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate52.java
+++ b/hibernate52-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate52.java
@@ -41,6 +41,8 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -72,6 +74,48 @@ public class DdlGeneratorHibernate52 implements DdlGenerator {
         }
 
         registryBuilder.applySetting("hibernate.dialect", dialectClassName);
+        
+        if (!mojo.getPersistenceProperties().isEmpty()) {
+            mojo.getLog().info("Applying persistence properties set in POM...");
+            final Map<String, String> properties = mojo
+                .getPersistenceProperties()
+                .entrySet()
+                .stream()
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.hbm2ddl.auto"
+                    )
+                )
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.hbm2ddl.auto"
+                    )
+                )
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.dialect"
+                    )
+                )
+                .collect(
+                    Collectors.toMap(
+                        property -> property.getKey(),
+                        property -> property.getValue()
+                    )
+                );
+
+            for (final Map.Entry<String, String> property : properties
+                .entrySet()) {
+                mojo.getLog().info(
+                    String.format(
+                        "Setting peristence property %s = %s",
+                        property.getKey(),
+                        property.getValue()
+                    )
+                );
+            }
+            
+            registryBuilder.applySettings(properties);
+        }
 
         final StandardServiceRegistry standardRegistry = registryBuilder.build();
 

--- a/hibernate53-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate53.java
+++ b/hibernate53-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate53.java
@@ -88,11 +88,6 @@ public class DdlGeneratorHibernate53 implements DdlGenerator {
                 )
                 .filter(
                     property -> !property.getKey().equals(
-                        "hibernate.hbm2ddl.auto"
-                    )
-                )
-                .filter(
-                    property -> !property.getKey().equals(
                         "hibernate.dialect"
                     )
                 )

--- a/hibernate53-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate53.java
+++ b/hibernate53-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate53.java
@@ -41,6 +41,8 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -72,6 +74,48 @@ public class DdlGeneratorHibernate53 implements DdlGenerator {
         }
 
         registryBuilder.applySetting("hibernate.dialect", dialectClassName);
+
+        if (!mojo.getPersistenceProperties().isEmpty()) {
+            mojo.getLog().info("Applying persistence properties set in POM...");
+            final Map<String, String> properties = mojo
+                .getPersistenceProperties()
+                .entrySet()
+                .stream()
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.hbm2ddl.auto"
+                    )
+                )
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.hbm2ddl.auto"
+                    )
+                )
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.dialect"
+                    )
+                )
+                .collect(
+                    Collectors.toMap(
+                        property -> property.getKey(),
+                        property -> property.getValue()
+                    )
+                );
+
+            for (final Map.Entry<String, String> property : properties
+                .entrySet()) {
+                mojo.getLog().info(
+                    String.format(
+                        "Setting peristence property %s = %s",
+                        property.getKey(),
+                        property.getValue()
+                    )
+                );
+            }
+
+            registryBuilder.applySettings(properties);
+        }
 
         final StandardServiceRegistry standardRegistry = registryBuilder.build();
 

--- a/hibernate54-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate54.java
+++ b/hibernate54-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate54.java
@@ -89,11 +89,6 @@ public class DdlGeneratorHibernate54 implements DdlGenerator {
                 )
                 .filter(
                     property -> !property.getKey().equals(
-                        "hibernate.hbm2ddl.auto"
-                    )
-                )
-                .filter(
-                    property -> !property.getKey().equals(
                         "hibernate.dialect"
                     )
                 )

--- a/hibernate54-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate54.java
+++ b/hibernate54-ddl-maven-plugin/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlGeneratorHibernate54.java
@@ -41,6 +41,8 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -61,17 +63,60 @@ public class DdlGeneratorHibernate54 implements DdlGenerator {
         throws MojoFailureException {
 
         final StandardServiceRegistryBuilder registryBuilder
-                                                 = new StandardServiceRegistryBuilder();
+            = new StandardServiceRegistryBuilder();
         processPersistenceXml(registryBuilder, mojo);
 
         if (mojo.isCreateDropStatements()) {
-            registryBuilder.applySetting("hibernate.hbm2ddl.auto",
-                                         "create-drop");
+            registryBuilder.applySetting(
+                "hibernate.hbm2ddl.auto", "create-drop"
+            );
         } else {
             registryBuilder.applySetting("hibernate.hbm2ddl.auto", "create");
         }
 
         registryBuilder.applySetting("hibernate.dialect", dialectClassName);
+
+        if (!mojo.getPersistenceProperties().isEmpty()) {
+            mojo.getLog().info("Applying persistence properties set in POM...");
+            final Map<String, String> properties = mojo
+                .getPersistenceProperties()
+                .entrySet()
+                .stream()
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.hbm2ddl.auto"
+                    )
+                )
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.hbm2ddl.auto"
+                    )
+                )
+                .filter(
+                    property -> !property.getKey().equals(
+                        "hibernate.dialect"
+                    )
+                )
+                .collect(
+                    Collectors.toMap(
+                        property -> property.getKey(),
+                        property -> property.getValue()
+                    )
+                );
+
+            for (final Map.Entry<String, String> property : properties
+                .entrySet()) {
+                mojo.getLog().info(
+                    String.format(
+                        "Setting peristence property %s = %s",
+                        property.getKey(),
+                        property.getValue()
+                    )
+                );
+            }
+            
+            registryBuilder.applySettings(properties);
+        }
 
         final StandardServiceRegistry standardRegistry = registryBuilder.build();
 
@@ -192,6 +237,7 @@ public class DdlGeneratorHibernate54 implements DdlGenerator {
     private static class PersistenceXmlHandler extends DefaultHandler {
 
         private final transient StandardServiceRegistryBuilder registryBuilder;
+
         private final transient Set<String> propertiesToUse;
 
         private final transient Log log;

--- a/hibernate54-ddl-maven-plugin/src/test/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlMojoTest.java
+++ b/hibernate54-ddl-maven-plugin/src/test/java/de/jpdigital/maven/plugins/hibernate5ddl/DdlMojoTest.java
@@ -38,8 +38,11 @@ import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 
 /**
  * TestSuite for testing the {@link GenerateDdlMojo}.

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
             <dependency>
                 <groupId>org.reflections</groupId>
                 <artifactId>reflections</artifactId>
-                <version>0.9.12</version>
+                <version>0.9.11</version>
             </dependency>
             <dependency>
                 <groupId>javax.transaction</groupId>


### PR DESCRIPTION
Adds the option the set persistence properties (expect `hibernate.hbm2ddl.auto` and `hibernate.dialect` which are automatically set by the plugin) in configuration of the plugin . 

Fixes #28 