### PR TITLE
EntityFinder - fix usages of Reflection library retrieve only Entity classes in the configured packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 
 *.log
 /hibernate5-ddl-maven-plugin-core/nbproject/
+*.iml
+.idea/

--- a/hibernate5-ddl-maven-plugin-core/pom.xml
+++ b/hibernate5-ddl-maven-plugin-core/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.github.fabio-bonfante</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-RC1</version>
+        <version>2.4.0-RC2</version>
     </parent>
 
     <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-    <version>2.4.0-RC1</version>
+    <version>2.4.0-RC2</version>
     <packaging>jar</packaging>
 
     <name>Maven DDL generator plugin for Hibernate 5 Core</name>

--- a/hibernate5-ddl-maven-plugin-core/pom.xml
+++ b/hibernate5-ddl-maven-plugin-core/pom.xml
@@ -3,14 +3,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.github.fabio-bonfante</groupId>
+        <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-RC2</version>
+        <version>2.4.0-RC3</version>
     </parent>
 
-    <groupId>com.github.fabio-bonfante</groupId>
+    <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
     <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-    <version>2.4.0-RC2</version>
+    <version>2.4.0-RC3</version>
     <packaging>jar</packaging>
 
     <name>Maven DDL generator plugin for Hibernate 5 Core</name>

--- a/hibernate5-ddl-maven-plugin-core/pom.xml
+++ b/hibernate5-ddl-maven-plugin-core/pom.xml
@@ -3,14 +3,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>de.jpdigital</groupId>
+        <groupId>com.github.fabio-bonfante</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0-RC1</version>
     </parent>
 
-    <groupId>de.jpdigital</groupId>
+    <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0-RC1</version>
     <packaging>jar</packaging>
 
     <name>Maven DDL generator plugin for Hibernate 5 Core</name>
@@ -211,19 +211,19 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-gpg-plugin</artifactId>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>sign-artifacts</id>-->
+<!--                        <phase>verify</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>sign</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/hibernate5-ddl-maven-plugin-core/pom.xml
+++ b/hibernate5-ddl-maven-plugin-core/pom.xml
@@ -129,6 +129,22 @@
             <groupId>javax.transaction</groupId>
             <artifactId>javax.transaction-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/hibernate5-ddl-maven-plugin-core/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/EntityFinder.java
+++ b/hibernate5-ddl-maven-plugin-core/src/main/java/de/jpdigital/maven/plugins/hibernate5ddl/EntityFinder.java
@@ -25,6 +25,7 @@ import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -80,8 +81,9 @@ final class EntityFinder {
 
         final Reflections reflections;
         if (project == null) {
-            reflections = new Reflections(
-                ClasspathHelper.forPackage(packageName));
+            reflections = new Reflections(new ConfigurationBuilder()
+                    .setUrls(ClasspathHelper.forPackage(packageName))
+                    .filterInputsBy(new FilterBuilder().includePackage(packageName)));
         } else {
             final List<String> classPathElems = new ArrayList<>();
             try {
@@ -122,6 +124,7 @@ final class EntityFinder {
                         new SubTypesScanner(),
                         new TypeAnnotationsScanner()
                     )
+                    .filterInputsBy(new FilterBuilder().includePackage(packageName))
             );
 //            reflections = new Reflections(
 //                ClasspathHelper.forPackage(packageName, classLoader),

--- a/hibernate5-ddl-maven-plugin-core/src/test/java/com/example/p1/TestEntity1.java
+++ b/hibernate5-ddl-maven-plugin-core/src/test/java/com/example/p1/TestEntity1.java
@@ -1,0 +1,7 @@
+package com.example.p1;
+
+import javax.persistence.Entity;
+
+@Entity
+public class TestEntity1 {
+}

--- a/hibernate5-ddl-maven-plugin-core/src/test/java/com/example/p2/TestEntity2.java
+++ b/hibernate5-ddl-maven-plugin-core/src/test/java/com/example/p2/TestEntity2.java
@@ -1,0 +1,7 @@
+package com.example.p2;
+
+import javax.persistence.Entity;
+
+@Entity
+public class TestEntity2 {
+}

--- a/hibernate5-ddl-maven-plugin-core/src/test/java/de/jpdigital/maven/plugins/hibernate5ddl/EntityFinderTest.java
+++ b/hibernate5-ddl-maven-plugin-core/src/test/java/de/jpdigital/maven/plugins/hibernate5ddl/EntityFinderTest.java
@@ -1,0 +1,25 @@
+package de.jpdigital.maven.plugins.hibernate5ddl;
+
+import org.apache.maven.monitor.logging.DefaultLog;
+import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EntityFinderTest {
+
+    private final DefaultLog log = new DefaultLog(new ConsoleLogger());
+
+    @Test
+    public void findEntities() throws MojoFailureException {
+        assertEquals("Found all entities in 'com.example' packages",
+                2, EntityFinder.forPackage(null, log, "com.example", false).findEntities().size());
+        assertEquals("Found entities only in 'com.example.p1' packages",
+                1, EntityFinder.forPackage(null, log, "com.example.p1", false).findEntities().size());
+        assertEquals("Found entities only in 'com.example.p2' packages",
+                1, EntityFinder.forPackage(null, log, "com.example.p2", false).findEntities().size());
+    }
+
+
+}

--- a/hibernate50-ddl-maven-plugin/pom.xml
+++ b/hibernate50-ddl-maven-plugin/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>com.github.fabio-bonfante</groupId>
+        <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-RC2</version>
+        <version>2.4.0-RC3</version>
     </parent>
     
-    <groupId>com.github.fabio-bonfante</groupId>
+    <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
     <artifactId>hibernate50-ddl-maven-plugin</artifactId>
-    <version>2.4.0-RC2</version>
+    <version>2.4.0-RC3</version>
     <name>Maven DDL generator plugin for Hibernate 5.0</name>
     <packaging>maven-plugin</packaging>
     
@@ -81,14 +81,14 @@
     
     <dependencies>
         <dependency>
-            <groupId>com.github.fabio-bonfante</groupId>
+            <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-RC2</version>
+            <version>2.4.0-RC3</version>
         </dependency>
         <dependency>
-            <groupId>com.github.fabio-bonfante</groupId>
+            <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-RC2</version>
+            <version>2.4.0-RC3</version>
             <classifier>sources</classifier>
         </dependency>
         

--- a/hibernate50-ddl-maven-plugin/pom.xml
+++ b/hibernate50-ddl-maven-plugin/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.github.fabio-bonfante</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-RC1</version>
+        <version>2.4.0-RC2</version>
     </parent>
     
     <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate50-ddl-maven-plugin</artifactId>
-    <version>2.4.0-RC1</version>
+    <version>2.4.0-RC2</version>
     <name>Maven DDL generator plugin for Hibernate 5.0</name>
     <packaging>maven-plugin</packaging>
     
@@ -83,12 +83,12 @@
         <dependency>
             <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-RC1</version>
+            <version>2.4.0-RC2</version>
         </dependency>
         <dependency>
             <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-RC1</version>
+            <version>2.4.0-RC2</version>
             <classifier>sources</classifier>
         </dependency>
         

--- a/hibernate50-ddl-maven-plugin/pom.xml
+++ b/hibernate50-ddl-maven-plugin/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>de.jpdigital</groupId>
+        <groupId>com.github.fabio-bonfante</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0-RC1</version>
     </parent>
     
-    <groupId>de.jpdigital</groupId>
+    <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate50-ddl-maven-plugin</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0-RC1</version>
     <name>Maven DDL generator plugin for Hibernate 5.0</name>
     <packaging>maven-plugin</packaging>
     
@@ -81,14 +81,14 @@
     
     <dependencies>
         <dependency>
-            <groupId>de.jpdigital</groupId>
+            <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>2.4.0-RC1</version>
         </dependency>
         <dependency>
-            <groupId>de.jpdigital</groupId>
+            <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>2.4.0-RC1</version>
             <classifier>sources</classifier>
         </dependency>
         
@@ -207,20 +207,20 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-gpg-plugin</artifactId>-->
+<!--                <version>1.6</version>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>sign-artifacts</id>-->
+<!--                        <phase>verify</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>sign</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -475,19 +475,19 @@
                         </configuration>
                     </plugin>
             
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
+<!--                    <plugin>-->
+<!--                        <groupId>org.apache.maven.plugins</groupId>-->
+<!--                        <artifactId>maven-gpg-plugin</artifactId>-->
+<!--                        <executions>-->
+<!--                            <execution>-->
+<!--                                <id>sign-artifacts</id>-->
+<!--                                <phase>verify</phase>-->
+<!--                                <goals>-->
+<!--                                    <goal>sign</goal>-->
+<!--                                </goals>-->
+<!--                            </execution>-->
+<!--                        </executions>-->
+<!--                    </plugin>-->
                 </plugins>
             </build>
             

--- a/hibernate51-ddl-maven-plugin/pom.xml
+++ b/hibernate51-ddl-maven-plugin/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>de.jpdigital</groupId>
+        <groupId>com.github.fabio-bonfante</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0-RC1</version>
     </parent>
     
-    <groupId>de.jpdigital</groupId>
+    <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate51-ddl-maven-plugin</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0-RC1</version>
     <name>Maven DDL generator plugin for Hibernate 5.1</name>
     <packaging>maven-plugin</packaging>
     
@@ -81,9 +81,9 @@
     
     <dependencies>
         <dependency>
-            <groupId>de.jpdigital</groupId>
+            <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>2.4.0-RC1</version>
         </dependency>
         
         <dependency>
@@ -189,19 +189,19 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-gpg-plugin</artifactId>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>sign-artifacts</id>-->
+<!--                        <phase>verify</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>sign</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/hibernate51-ddl-maven-plugin/pom.xml
+++ b/hibernate51-ddl-maven-plugin/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.github.fabio-bonfante</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-RC1</version>
+        <version>2.4.0-RC2</version>
     </parent>
     
     <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate51-ddl-maven-plugin</artifactId>
-    <version>2.4.0-RC1</version>
+    <version>2.4.0-RC2</version>
     <name>Maven DDL generator plugin for Hibernate 5.1</name>
     <packaging>maven-plugin</packaging>
     
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-RC1</version>
+            <version>2.4.0-RC2</version>
         </dependency>
         
         <dependency>

--- a/hibernate51-ddl-maven-plugin/pom.xml
+++ b/hibernate51-ddl-maven-plugin/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>com.github.fabio-bonfante</groupId>
+        <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-RC2</version>
+        <version>2.4.0-RC3</version>
     </parent>
     
-    <groupId>com.github.fabio-bonfante</groupId>
+    <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
     <artifactId>hibernate51-ddl-maven-plugin</artifactId>
-    <version>2.4.0-RC2</version>
+    <version>2.4.0-RC3</version>
     <name>Maven DDL generator plugin for Hibernate 5.1</name>
     <packaging>maven-plugin</packaging>
     
@@ -81,9 +81,9 @@
     
     <dependencies>
         <dependency>
-            <groupId>com.github.fabio-bonfante</groupId>
+            <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-RC2</version>
+            <version>2.4.0-RC3</version>
         </dependency>
         
         <dependency>

--- a/hibernate52-ddl-maven-plugin/pom.xml
+++ b/hibernate52-ddl-maven-plugin/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.github.fabio-bonfante</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-RC1</version>
+        <version>2.4.0-RC2</version>
     </parent>
     
     <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate52-ddl-maven-plugin</artifactId>
-    <version>2.4.0-RC1</version>
+    <version>2.4.0-RC2</version>
     <name>Maven DDL generator plugin for Hibernate 5.2</name>
     <packaging>maven-plugin</packaging>
     
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-RC1</version>
+            <version>2.4.0-RC2</version>
         </dependency>
         
         <dependency>

--- a/hibernate52-ddl-maven-plugin/pom.xml
+++ b/hibernate52-ddl-maven-plugin/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>com.github.fabio-bonfante</groupId>
+        <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-RC2</version>
+        <version>2.4.0-RC3</version>
     </parent>
     
-    <groupId>com.github.fabio-bonfante</groupId>
+    <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
     <artifactId>hibernate52-ddl-maven-plugin</artifactId>
-    <version>2.4.0-RC2</version>
+    <version>2.4.0-RC3</version>
     <name>Maven DDL generator plugin for Hibernate 5.2</name>
     <packaging>maven-plugin</packaging>
     
@@ -81,9 +81,9 @@
     
     <dependencies>
         <dependency>
-            <groupId>com.github.fabio-bonfante</groupId>
+            <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-RC2</version>
+            <version>2.4.0-RC3</version>
         </dependency>
         
         <dependency>

--- a/hibernate52-ddl-maven-plugin/pom.xml
+++ b/hibernate52-ddl-maven-plugin/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>de.jpdigital</groupId>
+        <groupId>com.github.fabio-bonfante</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0-RC1</version>
     </parent>
     
-    <groupId>de.jpdigital</groupId>
+    <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate52-ddl-maven-plugin</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0-RC1</version>
     <name>Maven DDL generator plugin for Hibernate 5.2</name>
     <packaging>maven-plugin</packaging>
     
@@ -81,9 +81,9 @@
     
     <dependencies>
         <dependency>
-            <groupId>de.jpdigital</groupId>
+            <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>2.4.0-RC1</version>
         </dependency>
         
         <dependency>
@@ -188,19 +188,19 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-gpg-plugin</artifactId>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>sign-artifacts</id>-->
+<!--                        <phase>verify</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>sign</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/hibernate53-ddl-maven-plugin/pom.xml
+++ b/hibernate53-ddl-maven-plugin/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.github.fabio-bonfante</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-RC1</version>
+        <version>2.4.0-RC2</version>
     </parent>
     
     <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate53-ddl-maven-plugin</artifactId>
-    <version>2.4.0-RC1</version>
+    <version>2.4.0-RC2</version>
     <name>Maven DDL generator plugin for Hibernate 5.3</name>
     <packaging>maven-plugin</packaging>
     
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-RC1</version>
+            <version>2.4.0-RC2</version>
         </dependency>
         
         <dependency>

--- a/hibernate53-ddl-maven-plugin/pom.xml
+++ b/hibernate53-ddl-maven-plugin/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>de.jpdigital</groupId>
+        <groupId>com.github.fabio-bonfante</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0-RC1</version>
     </parent>
     
-    <groupId>de.jpdigital</groupId>
+    <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate53-ddl-maven-plugin</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0-RC1</version>
     <name>Maven DDL generator plugin for Hibernate 5.3</name>
     <packaging>maven-plugin</packaging>
     
@@ -81,9 +81,9 @@
     
     <dependencies>
         <dependency>
-            <groupId>de.jpdigital</groupId>
+            <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>2.4.0-RC1</version>
         </dependency>
         
         <dependency>
@@ -188,19 +188,19 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-gpg-plugin</artifactId>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>sign-artifacts</id>-->
+<!--                        <phase>verify</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>sign</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/hibernate53-ddl-maven-plugin/pom.xml
+++ b/hibernate53-ddl-maven-plugin/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>com.github.fabio-bonfante</groupId>
+        <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-RC2</version>
+        <version>2.4.0-RC3</version>
     </parent>
     
-    <groupId>com.github.fabio-bonfante</groupId>
+    <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
     <artifactId>hibernate53-ddl-maven-plugin</artifactId>
-    <version>2.4.0-RC2</version>
+    <version>2.4.0-RC3</version>
     <name>Maven DDL generator plugin for Hibernate 5.3</name>
     <packaging>maven-plugin</packaging>
     
@@ -81,9 +81,9 @@
     
     <dependencies>
         <dependency>
-            <groupId>com.github.fabio-bonfante</groupId>
+            <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-RC2</version>
+            <version>2.4.0-RC3</version>
         </dependency>
         
         <dependency>

--- a/hibernate54-ddl-maven-plugin/pom.xml
+++ b/hibernate54-ddl-maven-plugin/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>com.github.fabio-bonfante</groupId>
+        <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-RC2</version>
+        <version>2.4.0-RC3</version>
     </parent>
     
-    <groupId>com.github.fabio-bonfante</groupId>
+    <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
     <artifactId>hibernate54-ddl-maven-plugin</artifactId>
-    <version>2.4.0-RC2</version>
+    <version>2.4.0-RC3</version>
     <name>Maven DDL generator plugin for Hibernate 5.4</name>
     <packaging>maven-plugin</packaging>
     
@@ -81,9 +81,9 @@
     
     <dependencies>
         <dependency>
-            <groupId>com.github.fabio-bonfante</groupId>
+            <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-RC2</version>
+            <version>2.4.0-RC3</version>
         </dependency>
         
         <dependency>

--- a/hibernate54-ddl-maven-plugin/pom.xml
+++ b/hibernate54-ddl-maven-plugin/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>com.github.fabio-bonfante</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-RC1</version>
+        <version>2.4.0-RC2</version>
     </parent>
     
     <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate54-ddl-maven-plugin</artifactId>
-    <version>2.4.0-RC1</version>
+    <version>2.4.0-RC2</version>
     <name>Maven DDL generator plugin for Hibernate 5.4</name>
     <packaging>maven-plugin</packaging>
     
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-RC1</version>
+            <version>2.4.0-RC2</version>
         </dependency>
         
         <dependency>

--- a/hibernate54-ddl-maven-plugin/pom.xml
+++ b/hibernate54-ddl-maven-plugin/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>de.jpdigital</groupId>
+        <groupId>com.github.fabio-bonfante</groupId>
         <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>2.4.0-RC1</version>
     </parent>
     
-    <groupId>de.jpdigital</groupId>
+    <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate54-ddl-maven-plugin</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0-RC1</version>
     <name>Maven DDL generator plugin for Hibernate 5.4</name>
     <packaging>maven-plugin</packaging>
     
@@ -81,9 +81,9 @@
     
     <dependencies>
         <dependency>
-            <groupId>de.jpdigital</groupId>
+            <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-core</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>2.4.0-RC1</version>
         </dependency>
         
         <dependency>
@@ -181,19 +181,19 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-gpg-plugin</artifactId>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>sign-artifacts</id>-->
+<!--                        <phase>verify</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>sign</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.fabio-bonfante</groupId>
+    <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
     <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-    <version>2.4.0-RC2</version>
+    <version>2.4.0-RC3</version>
     <packaging>pom</packaging>
 
     <name>Maven DDL generator plugin for Hibernate 5</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-    <version>2.4.0-RC1</version>
+    <version>2.4.0-RC2</version>
     <packaging>pom</packaging>
 
     <name>Maven DDL generator plugin for Hibernate 5</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>de.jpdigital</groupId>
+    <groupId>com.github.fabio-bonfante</groupId>
     <artifactId>hibernate5-ddl-maven-plugin</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.0-RC1</version>
     <packaging>pom</packaging>
 
     <name>Maven DDL generator plugin for Hibernate 5</name>
@@ -347,19 +347,19 @@
                 <artifactId>maven-jar-plugin</artifactId>
             </plugin>
             
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-gpg-plugin</artifactId>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>sign-artifacts</id>-->
+<!--                        <phase>verify</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>sign</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -14,7 +14,7 @@ To use the plugin add it the the build plugins in your POM:
     <build>
         [...]
         <plugin>
-            <groupId>de.jpdigital</groupId>
+            <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-hibernate52</artifactId> <!-- Change to match your Hibernate version -->
             <version>2.0.0</version> <!-- Change to latest version available -->
             <configuration>
@@ -103,7 +103,7 @@ file(s) using several parameters:
     <build>
         [...]
         <plugin>
-            <groupId>de.jpdigital</groupId>
+            <groupId>com.github.fabio-bonfante</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-hibernate52</artifactId> <!-- Change to match your Hibernate version -->
             <version>2.2.0</version> <!-- Change to latest version available -->
             <configuration>

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -14,7 +14,7 @@ To use the plugin add it the the build plugins in your POM:
     <build>
         [...]
         <plugin>
-            <groupId>com.github.fabio-bonfante</groupId>
+            <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-hibernate52</artifactId> <!-- Change to match your Hibernate version -->
             <version>2.0.0</version> <!-- Change to latest version available -->
             <configuration>
@@ -103,7 +103,7 @@ file(s) using several parameters:
     <build>
         [...]
         <plugin>
-            <groupId>com.github.fabio-bonfante</groupId>
+            <groupId>com.github.fabio-bonfante.hibernate5-ddl-maven-plugin</groupId>
             <artifactId>hibernate5-ddl-maven-plugin-hibernate52</artifactId> <!-- Change to match your Hibernate version -->
             <version>2.2.0</version> <!-- Change to latest version available -->
             <configuration>


### PR DESCRIPTION
Using this plugin in my projects I've found that the packages configuration doesn't have effects, and all the Entity are found creating the ddl for all of them.

Looking at the code and at the Reflection library documentation seems that a `filterInputsBy(new FilterBuilder().includePackage(packageName)));` is needed to return the classes in a given package.

Added a unit-test inside the plugin-core (not covering all the code, but I've no experience in actual testing/developing maven plugins)... hope it helps. 